### PR TITLE
Fix ProductQueryRepository brace

### DIFF
--- a/ERP.Server.Infrastructure/Data/Repositories/ProductQueryRepository.cs
+++ b/ERP.Server.Infrastructure/Data/Repositories/ProductQueryRepository.cs
@@ -32,7 +32,6 @@ public class ProductQueryRepository : Base.QueryRepository<Product>, IProductQue
         // Apply the index
         _collection.Indexes.CreateOne(model);
     }
-    }
 
     public async Task<IReadOnlyList<Product>> GetProductsByTypeAsync(ProductType type, CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
## Summary
- remove redundant closing brace in `ProductQueryRepository`

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f0a3844b48328ae3c2b5f252ca304