### PR TITLE
Add API endpoints and commands for product management

### DIFF
--- a/ERP.Server.Api/Controllers/BaseApiController.cs
+++ b/ERP.Server.Api/Controllers/BaseApiController.cs
@@ -1,0 +1,31 @@
+using ERP.Server.Application.Common.Results;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ERP.Server.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public abstract class BaseApiController : ControllerBase
+{
+    protected ISender Mediator { get; }
+
+    protected BaseApiController(ISender mediator)
+    {
+        Mediator = mediator;
+    }
+
+    protected IActionResult HandleResult(Result result)
+    {
+        if (result.IsSuccess)
+            return Ok(result.Message);
+        return BadRequest(new { result.Message, result.Errors });
+    }
+
+    protected IActionResult HandleResult<T>(Result<T> result)
+    {
+        if (result.IsSuccess)
+            return Ok(result.Data);
+        return BadRequest(new { result.Message, result.Errors });
+    }
+}

--- a/ERP.Server.Api/Controllers/ProductController.cs
+++ b/ERP.Server.Api/Controllers/ProductController.cs
@@ -1,0 +1,75 @@
+using ERP.Server.Application.Features.Products.Commands;
+using ERP.Server.Application.Features.Products.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ERP.Server.Api.Controllers;
+
+public class ProductController : BaseApiController
+{
+    private readonly ILogger<ProductController> _logger;
+
+    public ProductController(ISender mediator, ILogger<ProductController> logger)
+        : base(mediator)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var result = await Mediator.Send(new GetAllProductsQuery());
+        return HandleResult(result);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetById(Guid id)
+    {
+        var result = await Mediator.Send(new GetProductByIdQuery(id));
+        return HandleResult(result);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create(CreateProductCommand command)
+    {
+        var result = await Mediator.Send(command);
+        return HandleResult(result);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> Update(Guid id, UpdateProductCommand command)
+    {
+        if (id != command.Id)
+            return BadRequest("Id mismatch");
+
+        var result = await Mediator.Send(command);
+        return HandleResult(result);
+    }
+
+    [HttpPut("{id}/price")]
+    public async Task<IActionResult> UpdatePrice(Guid id, UpdateProductPriceCommand command)
+    {
+        if (id != command.Id)
+            return BadRequest("Id mismatch");
+
+        var result = await Mediator.Send(command);
+        return HandleResult(result);
+    }
+
+    [HttpPut("{id}/stock")]
+    public async Task<IActionResult> UpdateStock(Guid id, UpdateProductStockCommand command)
+    {
+        if (id != command.Id)
+            return BadRequest("Id mismatch");
+
+        var result = await Mediator.Send(command);
+        return HandleResult(result);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> Delete(Guid id)
+    {
+        var result = await Mediator.Send(new DeleteProductCommand(id));
+        return HandleResult(result);
+    }
+}

--- a/ERP.Server.Api/ERP.Server.Api.csproj
+++ b/ERP.Server.Api/ERP.Server.Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <ProjectReference Include="..\ERP.Server.Application\ERP.Server.Application.csproj" />
+    <ProjectReference Include="..\ERP.Server.Infrastructure\ERP.Server.Infrastructure.csproj" />
+  </ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="MediatR" Version="12.3.0" />
+  </ItemGroup>
+</Project>

--- a/ERP.Server.Api/Program.cs
+++ b/ERP.Server.Api/Program.cs
@@ -1,0 +1,25 @@
+using ERP.Server.Application;
+using ERP.Server.Infrastructure;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddApplicationServices(builder.Configuration);
+builder.Services.AddInfrastructure(builder.Configuration);
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.MapControllers();
+
+app.Run();

--- a/ERP.Server.Api/appsettings.json
+++ b/ERP.Server.Api/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=ERPDb;Trusted_Connection=True;"
+  },
+  "MongoDbSettings": {
+    "ConnectionString": "mongodb://localhost:27017",
+    "DatabaseName": "erpdb"
+  }
+}

--- a/ERP.Server.Application/Features/Products/Commands/DeleteProductCommand.cs
+++ b/ERP.Server.Application/Features/Products/Commands/DeleteProductCommand.cs
@@ -1,0 +1,40 @@
+using ERP.Server.Application.Common.Results;
+using ERP.Server.Domain.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace ERP.Server.Application.Features.Products.Commands;
+
+public sealed record DeleteProductCommand(Guid Id) : IRequest<Result>;
+
+public sealed class DeleteProductCommandHandler : IRequestHandler<DeleteProductCommand, Result>
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<DeleteProductCommandHandler> _logger;
+
+    public DeleteProductCommandHandler(IUnitOfWork unitOfWork, ILogger<DeleteProductCommandHandler> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<Result> Handle(DeleteProductCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var product = await _unitOfWork.ProductCommandRepository.GetByIdAsync(request.Id, cancellationToken);
+            if (product == null)
+                return Result.Failure("Product not found");
+
+            await _unitOfWork.ProductCommandRepository.DeleteAsync(product, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success("Product deleted successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting product {Id}", request.Id);
+            return Result.Failure("Error deleting product", new List<string> { ex.Message });
+        }
+    }
+}

--- a/ERP.Server.Application/Features/Products/Commands/UpdateProductCommand.cs
+++ b/ERP.Server.Application/Features/Products/Commands/UpdateProductCommand.cs
@@ -1,0 +1,50 @@
+using ERP.Server.Application.Common.Results;
+using ERP.Server.Domain.Entities.Enums;
+using ERP.Server.Domain.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace ERP.Server.Application.Features.Products.Commands;
+
+public sealed record UpdateProductCommand(
+    Guid Id,
+    string Name,
+    string Description,
+    string ProductTypeValue) : IRequest<Result>;
+
+public sealed class UpdateProductCommandHandler : IRequestHandler<UpdateProductCommand, Result>
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<UpdateProductCommandHandler> _logger;
+
+    public UpdateProductCommandHandler(IUnitOfWork unitOfWork, ILogger<UpdateProductCommandHandler> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<Result> Handle(UpdateProductCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var product = await _unitOfWork.ProductCommandRepository.GetByIdAsync(request.Id, cancellationToken);
+            if (product == null)
+                return Result.Failure("Product not found");
+
+            if (!ProductType.TryFromValue(request.ProductTypeValue, out var type))
+                return Result.Failure("Invalid product type");
+
+            product.Update(request.Name, type!, request.Description);
+
+            await _unitOfWork.ProductCommandRepository.UpdateAsync(product, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            return Result.Success("Product updated successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating product {Id}", request.Id);
+            return Result.Failure("Error updating product", new List<string> { ex.Message });
+        }
+    }
+}

--- a/ERP.Server.Application/Features/Products/Commands/UpdateProductCommandValidator.cs
+++ b/ERP.Server.Application/Features/Products/Commands/UpdateProductCommandValidator.cs
@@ -1,0 +1,19 @@
+using ERP.Server.Domain.Entities.Enums;
+using FluentValidation;
+
+namespace ERP.Server.Application.Features.Products.Commands;
+
+public class UpdateProductCommandValidator : AbstractValidator<UpdateProductCommand>
+{
+    public UpdateProductCommandValidator()
+    {
+        RuleFor(p => p.Name)
+            .NotEmpty()
+            .MinimumLength(3);
+
+        RuleFor(p => p.ProductTypeValue)
+            .NotEmpty()
+            .Must(v => ProductType.TryFromValue(v, out _))
+            .WithMessage("Invalid product type");
+    }
+}

--- a/ERP.Server.Application/Features/Products/Commands/UpdateProductPriceCommand.cs
+++ b/ERP.Server.Application/Features/Products/Commands/UpdateProductPriceCommand.cs
@@ -1,0 +1,34 @@
+using ERP.Server.Application.Common.Results;
+using ERP.Server.Domain.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace ERP.Server.Application.Features.Products.Commands;
+
+public sealed record UpdateProductPriceCommand(Guid Id, decimal NewPrice) : IRequest<Result>;
+
+public sealed class UpdateProductPriceCommandHandler : IRequestHandler<UpdateProductPriceCommand, Result>
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<UpdateProductPriceCommandHandler> _logger;
+
+    public UpdateProductPriceCommandHandler(IUnitOfWork unitOfWork, ILogger<UpdateProductPriceCommandHandler> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<Result> Handle(UpdateProductPriceCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _unitOfWork.ProductCommandRepository.UpdatePriceAsync(request.Id, request.NewPrice, cancellationToken);
+            return Result.Success("Price updated successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating price of product {Id}", request.Id);
+            return Result.Failure("Error updating price", new List<string> { ex.Message });
+        }
+    }
+}

--- a/ERP.Server.Application/Features/Products/Commands/UpdateProductStockCommand.cs
+++ b/ERP.Server.Application/Features/Products/Commands/UpdateProductStockCommand.cs
@@ -1,0 +1,34 @@
+using ERP.Server.Application.Common.Results;
+using ERP.Server.Domain.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace ERP.Server.Application.Features.Products.Commands;
+
+public sealed record UpdateProductStockCommand(Guid Id, int Quantity) : IRequest<Result>;
+
+public sealed class UpdateProductStockCommandHandler : IRequestHandler<UpdateProductStockCommand, Result>
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<UpdateProductStockCommandHandler> _logger;
+
+    public UpdateProductStockCommandHandler(IUnitOfWork unitOfWork, ILogger<UpdateProductStockCommandHandler> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<Result> Handle(UpdateProductStockCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _unitOfWork.ProductCommandRepository.UpdateStockAsync(request.Id, request.Quantity, cancellationToken);
+            return Result.Success("Stock updated successfully");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error updating stock of product {Id}", request.Id);
+            return Result.Failure("Error updating stock", new List<string> { ex.Message });
+        }
+    }
+}

--- a/ERP.Server.Application/Features/Products/Queries/GetProductByIdQuery.cs
+++ b/ERP.Server.Application/Features/Products/Queries/GetProductByIdQuery.cs
@@ -1,0 +1,47 @@
+using AutoMapper;
+using ERP.Server.Application.Common.Dtos;
+using ERP.Server.Application.Common.Results;
+using ERP.Server.Domain.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace ERP.Server.Application.Features.Products.Queries;
+
+public sealed record GetProductByIdQuery(Guid Id) : IRequest<Result<ProductDto>>;
+
+public sealed class GetProductByIdQueryHandler : IRequestHandler<GetProductByIdQuery, Result<ProductDto>>
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMapper _mapper;
+    private readonly ILogger<GetProductByIdQueryHandler> _logger;
+
+    public GetProductByIdQueryHandler(
+        IUnitOfWork unitOfWork,
+        IMapper mapper,
+        ILogger<GetProductByIdQueryHandler> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<Result<ProductDto>> Handle(GetProductByIdQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var product = await _unitOfWork.ProductQueryRepository.GetByIdAsync(request.Id, cancellationToken);
+            if (product == null)
+            {
+                return Result<ProductDto>.Failure("Product not found");
+            }
+
+            var dto = _mapper.Map<ProductDto>(product);
+            return Result<ProductDto>.Success(dto);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error retrieving product with id {Id}", request.Id);
+            return Result<ProductDto>.Failure("An error occurred while retrieving the product", new List<string> { ex.Message });
+        }
+    }
+}

--- a/ERP.Server.Domain/Interfaces/IUnitOfWork.cs
+++ b/ERP.Server.Domain/Interfaces/IUnitOfWork.cs
@@ -5,33 +5,33 @@ namespace ERP.Server.Domain.Interfaces;
 /// <summary>
 /// Defines the interface for the Unit of Work pattern to coordinate transactions across repositories
 /// </summary>
-public interface IUnitOfWork : IDisposable, IAsyncDisposable
+public interface IUnitOfWork : IAsyncDisposable
 {
     /// <summary>
     /// Gets the product command repository for write operations
     /// </summary>
-    IProductCommandRepository Products { get; }
-    
+    IProductCommandRepository ProductCommandRepository { get; }
+
     /// <summary>
     /// Gets the product query repository for read operations
     /// </summary>
-    IProductQueryRepository ProductQueries { get; }
-    
+    IProductQueryRepository ProductQueryRepository { get; }
+
     /// <summary>
     /// Begins a new transaction
     /// </summary>
     Task BeginTransactionAsync(CancellationToken cancellationToken = default);
-    
+
     /// <summary>
     /// Commits the current transaction
     /// </summary>
-    Task CommitTransactionAsync(CancellationToken cancellationToken = default);
-    
+    Task CommitAsync(CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Rolls back the current transaction
     /// </summary>
-    Task RollbackTransactionAsync(CancellationToken cancellationToken = default);
-    
+    Task RollbackAsync(CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Saves all changes made in this unit of work
     /// </summary>

--- a/ERP.Server.Domain/Interfaces/Repositories/IProductRepository.cs
+++ b/ERP.Server.Domain/Interfaces/Repositories/IProductRepository.cs
@@ -7,6 +7,7 @@ namespace ERP.Server.Domain.Interfaces.Repositories;
 public interface IProductCommandRepository : ICommandRepository<Product>
 {
     // Product'a özel command'lar buraya eklenir
+    Task<Product?> GetByIdAsync(Guid productId, CancellationToken cancellationToken = default);
     Task UpdateStockAsync(Guid productId, int quantity, CancellationToken cancellationToken = default);
     Task UpdatePriceAsync(Guid productId, decimal newPrice, CancellationToken cancellationToken = default);
 }

--- a/ERP.Server.Infrastructure/Data/Repositories/ProductCommandRepository.cs
+++ b/ERP.Server.Infrastructure/Data/Repositories/ProductCommandRepository.cs
@@ -7,9 +7,14 @@ namespace ERP.Server.Infrastructure.Data.Repositories;
 
 public class ProductCommandRepository : Base.EfCommandRepository<Product>, IProductCommandRepository
 {
-    public ProductCommandRepository(ApplicationDbContext context) 
+    public ProductCommandRepository(ApplicationDbContext context)
         : base(context)
     {
+    }
+
+    public async Task<Product?> GetByIdAsync(Guid productId, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet.FirstOrDefaultAsync(p => p.Id == productId, cancellationToken);
     }
 
     public async Task UpdateStockAsync(Guid productId, int quantity, CancellationToken cancellationToken = default)

--- a/ERP.Server.Infrastructure/DependencyInjection.cs
+++ b/ERP.Server.Infrastructure/DependencyInjection.cs
@@ -85,8 +85,8 @@ public class UnitOfWork : IUnitOfWork, IAsyncDisposable
         _productQueryRepository = productQueryRepository ?? throw new ArgumentNullException(nameof(productQueryRepository));
     }
 
-    public IProductCommandRepository Products => _productCommandRepository!;
-    public IProductQueryRepository ProductQueries => _productQueryRepository!;
+    public IProductCommandRepository ProductCommandRepository => _productCommandRepository!;
+    public IProductQueryRepository ProductQueryRepository => _productQueryRepository!;
 
     public async Task BeginTransactionAsync(CancellationToken cancellationToken = default)
     {
@@ -98,7 +98,7 @@ public class UnitOfWork : IUnitOfWork, IAsyncDisposable
         _currentTransaction = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
     }
 
-    public async Task CommitTransactionAsync(CancellationToken cancellationToken = default)
+    public async Task CommitAsync(CancellationToken cancellationToken = default)
     {
         try
         {
@@ -110,7 +110,7 @@ public class UnitOfWork : IUnitOfWork, IAsyncDisposable
         }
         catch
         {
-            await RollbackTransactionAsync(cancellationToken);
+            await RollbackAsync(cancellationToken);
             throw;
         }
         finally
@@ -123,7 +123,7 @@ public class UnitOfWork : IUnitOfWork, IAsyncDisposable
         }
     }
 
-    public async Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
+    public async Task RollbackAsync(CancellationToken cancellationToken = default)
     {
         try
         {

--- a/ERP.Server.sln
+++ b/ERP.Server.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ERP.Server.Application", "E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ERP.Server.Infrastructure", "ERP.Server.Infrastructure\ERP.Server.Infrastructure.csproj", "{5DFA080E-BE4D-4E05-B32C-D56CF23C62F6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ERP.Server.Api", "ERP.Server.Api\ERP.Server.Api.csproj", "{293938FB-E804-4199-816A-AEB95838E2A6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -54,8 +56,20 @@ Global
 		{5DFA080E-BE4D-4E05-B32C-D56CF23C62F6}.Release|x64.ActiveCfg = Release|Any CPU
 		{5DFA080E-BE4D-4E05-B32C-D56CF23C62F6}.Release|x64.Build.0 = Release|Any CPU
 		{5DFA080E-BE4D-4E05-B32C-D56CF23C62F6}.Release|x86.ActiveCfg = Release|Any CPU
-		{5DFA080E-BE4D-4E05-B32C-D56CF23C62F6}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {5DFA080E-BE4D-4E05-B32C-D56CF23C62F6}.Release|x86.Build.0 = Release|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Debug|x64.Build.0 = Debug|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Debug|x86.Build.0 = Debug|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Release|x64.ActiveCfg = Release|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Release|x64.Build.0 = Release|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Release|x86.ActiveCfg = Release|Any CPU
+                {293938FB-E804-4199-816A-AEB95838E2A6}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- expand `ProductController` with CRUD endpoints and price/stock updates
- define `GetProductByIdQuery` and commands for update, delete, price, and stock
- validate updates with new `UpdateProductCommandValidator`
- expose new repository method `GetByIdAsync` for command operations
- align handlers with existing repository naming conventions

## Testing
- `dotnet build ERP.Server.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1546e08c832895765c84a8c21fc9