### PR TITLE
Implement background outbox processor

### DIFF
--- a/ERP.Server.Infrastructure/DependencyInjection.cs
+++ b/ERP.Server.Infrastructure/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using Microsoft.EntityFrameworkCore;
 using ERP.Server.Infrastructure.Data;
 using ERP.Server.Infrastructure.Data.Repositories;
+using ERP.Server.Infrastructure.Data.Repositories.OutBoxes;
 using ERP.Server.Domain.Interfaces.Repositories;
 using ERP.Server.Domain.Entities;
 using MongoDB.Driver;
@@ -49,6 +50,7 @@ public static class DependencyInjection
 
         // Register Command Repositories (MSSQL)
         services.AddScoped<IProductCommandRepository, ProductCommandRepository>();
+        services.AddScoped<IOutboxRepository, OutBoxRepository>();
         
         services.AddScoped<ICurrentUserService, CurrentUserService>();
 

--- a/ERP.Server.Infrastructure/Services/Outbox/OutboxProcessorBackgroundService.cs
+++ b/ERP.Server.Infrastructure/Services/Outbox/OutboxProcessorBackgroundService.cs
@@ -1,0 +1,79 @@
+using ERP.Server.Domain.Entities;
+using ERP.Server.Domain.Entities.Enums;
+using ERP.Server.Domain.Interfaces.Repositories;
+using ERP.Server.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ERP.Server.Infrastructure.Services.Outbox;
+
+public class OutboxProcessorBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<OutboxProcessorBackgroundService> _logger;
+
+    public OutboxProcessorBackgroundService(IServiceScopeFactory scopeFactory, ILogger<OutboxProcessorBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await ProcessOutboxAsync(stoppingToken);
+            await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+    }
+
+    private async Task ProcessOutboxAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var outboxRepository = scope.ServiceProvider.GetRequiredService<IOutboxRepository>();
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var mongoContext = scope.ServiceProvider.GetRequiredService<MongoDbContext>();
+
+        var pendingMessages = await outboxRepository.GetAllAsync(cancellationToken);
+        if (pendingMessages.Count == 0)
+            return;
+
+        foreach (var message in pendingMessages)
+        {
+            try
+            {
+                if (message.TableName == TableNameEnum.Product)
+                {
+                    var product = await dbContext.Products.FirstOrDefaultAsync(p => p.Id == message.RecordId, cancellationToken);
+                    if (product != null)
+                    {
+                        var productsCollection = mongoContext.Database.GetCollection<Product>("products");
+                        switch (message.Operation)
+                        {
+                            case OperationEnum.Insert:
+                            case OperationEnum.Update:
+                                await productsCollection.ReplaceOneAsync(p => p.Id == product.Id, product, new ReplaceOptions { IsUpsert = true }, cancellationToken);
+                                break;
+                            case OperationEnum.Delete:
+                                await productsCollection.DeleteOneAsync(p => p.Id == product.Id, cancellationToken);
+                                break;
+                        }
+                        message.IsCompleted = true;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error processing outbox message {OutboxId}", message.Id);
+            }
+            finally
+            {
+                message.TryCount += 1;
+                await outboxRepository.UpdateAsync(message, cancellationToken);
+                await outboxRepository.SaveChangesAsync(cancellationToken);
+            }
+        }
+    }
+}

--- a/ERP.Server.WebAPI/Program.cs
+++ b/ERP.Server.WebAPI/Program.cs
@@ -1,5 +1,6 @@
 using ERP.Server.Application;
 using ERP.Server.Infrastructure;
+using ERP.Server.Infrastructure.Services.Outbox;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,6 +8,7 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services from other layers
 builder.Services.AddApplicationServices(builder.Configuration);
 builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddHostedService<OutboxProcessorBackgroundService>();
 
 builder.Services.AddControllers();
 


### PR DESCRIPTION
## Summary
- register `OutBoxRepository`
- add `OutboxProcessorBackgroundService` to copy products from SQL to Mongo
- run service from WebAPI host

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532eeabd688328b6fbaf543e98b605